### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "axios": "^1.6.0",
     "dotenv": "^16.3.0",
     "open": "^10.1.2",
-    "zod": "^3.22.0"
+    "zod": "^3.22.0",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/src/security/inputSanitizer.ts
+++ b/src/security/inputSanitizer.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+import DOMPurify from 'dompurify';
 import type { Logger } from '../types/index.js';
 
 export interface SanitizationConfig {
@@ -37,7 +38,7 @@ export class InputSanitizer {
     sqlInjection: /(\b(union|select|insert|update|delete|drop|create|alter|exec|execute)\b)|(-{2})|\/\*|\*\/|;/gi,
     
     // XSS patterns
-    xss: /<script[^>]*>.*?<\/script>|javascript:|on\w+\s*=|<iframe|<object|<embed|<link|<meta/gi,
+    xss: (input: string) => DOMPurify.sanitize(input),
     
     // Command injection patterns
     commandInjection: /[;&|`$(){}[\]\\]/g,


### PR DESCRIPTION
Potential fix for [https://github.com/kholcomb/Spotify-mcp-server/security/code-scanning/1](https://github.com/kholcomb/Spotify-mcp-server/security/code-scanning/1)

To fix the issue, replace the custom regular expression with a well-tested HTML sanitization library, such as `DOMPurify`. This library is specifically designed to sanitize HTML and prevent XSS attacks, handling edge cases and malformed HTML effectively. The `securityPatterns.xss` property should be updated to use `DOMPurify` for sanitization instead of relying on regex-based filtering.

**Steps to implement the fix:**
1. Install the `dompurify` library.
2. Import `DOMPurify` into the file.
3. Replace the `securityPatterns.xss` regex with a function that uses `DOMPurify` to sanitize input.
4. Ensure the sanitization process is integrated into the relevant parts of the `InputSanitizer` class.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
